### PR TITLE
Add `makeFederationSchemaPlugin`.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,152 +1,203 @@
 import {
+  AugmentedGraphQLFieldResolver,
+  ObjectFieldResolver,
   makeExtendSchemaPlugin,
   makePluginByCombiningPlugins,
   gql,
 } from "graphile-utils";
-import { Plugin } from "graphile-build";
+import { Build, Plugin } from "graphile-build";
+import { DirectiveNode } from "graphql";
 import printFederatedSchema from "./printFederatedSchema";
 import { ObjectTypeDefinition, Directive, StringValue } from "./AST";
 
 /**
- * This plugin installs the schema outlined in the Apollo Federation spec, and
- * the resolvers and types required. Comments have been added to make things
- * clearer for consumers, and the Apollo fields have been deprecated so that
- * users unconcerned with federation don't get confused.
- *
- * https://www.apollographql.com/docs/apollo-server/federation/federation-spec/#federation-schema-specification
+ * This function allows users to create their own version of the schema plugin.
  */
-const SchemaExtensionPlugin = makeExtendSchemaPlugin(build => {
-  const {
-    graphql: { GraphQLScalarType, getNullableType },
-    resolveNode,
-    $$isQuery,
-    $$nodeType,
-    getTypeByName,
-    inflection,
-    nodeIdFieldName,
-  } = build;
-  // Cache
-  let Query: any;
-  return {
-    typeDefs: gql`
-      """
-      Used to represent a federated entity via its keys.
-      """
-      scalar _Any
-
-      """
-      Used to represent a set of fields. Grammatically, a field set is a
-      selection set minus the braces.
-      """
-      scalar _FieldSet
-
-      """
-      A union of all federated types (those that use the @key directive).
-      """
-      union _Entity
-
-      """
-      Describes our federated service.
-      """
-      type _Service {
+export function makeFederationSchemaPlugin<TSource = any, TContext = any>(
+  generator: (
+    build: Build
+  ) =>
+    | AugmentedGraphQLFieldResolver<TSource, TContext>
+    | ObjectFieldResolver<TSource, TContext>
+): Plugin {
+  /**
+   * This plugin installs the schema outlined in the Apollo Federation spec, and
+   * the resolvers and types required. Comments have been added to make things
+   * clearer for consumers, and the Apollo fields have been deprecated so that
+   * users unconcerned with federation don't get confused.
+   *
+   * https://www.apollographql.com/docs/apollo-server/federation/federation-spec/#federation-schema-specification
+   */
+  const SchemaExtensionPlugin = makeExtendSchemaPlugin(build => {
+    const {
+      graphql: { GraphQLScalarType, getNullableType },
+      $$isQuery,
+      $$nodeType,
+      getTypeByName,
+      inflection,
+    } = build;
+    // Cache
+    let Query: any;
+    return {
+      typeDefs: gql`
         """
-        The GraphQL Schema Language definiton of our endpoint including the
-        Apollo Federation directives (but not their definitions or the special
-        Apollo Federation fields).
+        Used to represent a federated entity via its keys.
         """
-        sdl: String
-          @deprecated(reason: "Only Apollo Federation should use this")
+        scalar _Any
+
+        """
+        Used to represent a set of fields. Grammatically, a field set is a
+        selection set minus the braces.
+        """
+        scalar _FieldSet
+
+        """
+        A union of all federated types (those that use the @key directive).
+        """
+        union _Entity
+
+        """
+        Describes our federated service.
+        """
+        type _Service {
+          """
+          The GraphQL Schema Language definiton of our endpoint including the
+          Apollo Federation directives (but not their definitions or the special
+          Apollo Federation fields).
+          """
+          sdl: String
+            @deprecated(reason: "Only Apollo Federation should use this")
+        }
+
+        extend type Query {
+          """
+          Fetches a list of entities using their representations; used for Apollo
+          Federation.
+          """
+          _entities(representations: [_Any!]!): [_Entity]!
+            @deprecated(reason: "Only Apollo Federation should use this")
+          """
+          Entrypoint for Apollo Federation to determine more information about
+          this service.
+          """
+          _service: _Service!
+            @deprecated(reason: "Only Apollo Federation should use this")
+        }
+
+        directive @external on FIELD_DEFINITION
+        directive @requires(fields: _FieldSet!) on FIELD_DEFINITION
+        directive @provides(fields: _FieldSet!) on FIELD_DEFINITION
+        directive @key(fields: _FieldSet!) on OBJECT | INTERFACE
+      `,
+      resolvers: {
+        Query: {
+          _entities: generator(build),
+          _service(_, _args, _context, { schema }) {
+            return schema;
+          },
+        },
+
+        _Service: {
+          sdl(schema) {
+            return printFederatedSchema(schema);
+          },
+        },
+
+        _Entity: {
+          __resolveType(value) {
+            // This uses the same resolution as the Node interface, which can be found in graphile-build's NodePlugin
+            if (value === $$isQuery) {
+              if (!Query) Query = getTypeByName(inflection.builtin("Query"));
+              return Query;
+            } else if (value[$$nodeType]) {
+              return getNullableType(value[$$nodeType]);
+            }
+          },
+        },
+
+        _Any: new GraphQLScalarType({
+          name: "_Any",
+          serialize(value: any) {
+            return value;
+          },
+        }),
+      },
+    };
+  });
+
+  /*
+   * This plugin adds types to the _Entity union defined above.
+   */
+  const EntityPlugin: Plugin = builder => {
+    // Add our collected types to the _Entity union
+    builder.hook("GraphQLUnionType:types", (types, build, context) => {
+      const { Self } = context;
+      // If it's not the _Entity union, don't change it.
+      if (Self.name !== "_Entity") {
+        return types;
       }
 
-      extend type Query {
-        """
-        Fetches a list of entities using their representations; used for Apollo
-        Federation.
-        """
-        _entities(representations: [_Any!]!): [_Entity]!
-          @deprecated(reason: "Only Apollo Federation should use this")
-        """
-        Entrypoint for Apollo Federation to determine more information about
-        this service.
-        """
-        _service: _Service!
-          @deprecated(reason: "Only Apollo Federation should use this")
+      // If it's not the _Entity union, don't change it.
+      if (Self.name !== "_Entity") {
+        return types;
+      }
+      const { scopeByType } = build;
+
+      const newTypes = [...types];
+      for (const [type] of scopeByType) {
+        if (
+          type.astNode &&
+          type.astNode.directives &&
+          type.astNode.directives.some(
+            (directive: DirectiveNode) => directive.name.value === "key"
+          )
+        ) {
+          newTypes.push(type);
+        }
       }
 
-      directive @external on FIELD_DEFINITION
-      directive @requires(fields: _FieldSet!) on FIELD_DEFINITION
-      directive @provides(fields: _FieldSet!) on FIELD_DEFINITION
-      directive @key(fields: _FieldSet!) on OBJECT | INTERFACE
-    `,
-    resolvers: {
-      Query: {
-        _entities(data, { representations }, context, resolveInfo) {
-          const {
-            graphile: { fieldContext },
-          } = resolveInfo;
-          return representations.map((representation: any) => {
-            if (!representation || typeof representation !== "object") {
-              throw new Error("Invalid representation");
-            }
-            const { __typename, [nodeIdFieldName]: nodeId } = representation;
-            if (!__typename || typeof nodeId !== "string") {
-              throw new Error("Failed to interpret representation");
-            }
-            return resolveNode(
-              nodeId,
-              build,
-              fieldContext,
-              data,
-              context,
-              resolveInfo
-            );
-          });
-        },
+      // Add our types to the entity types
+      return newTypes;
+    });
+  };
 
-        _service(_, _args, _context, { schema }) {
-          return schema;
-        },
-      },
+  return makePluginByCombiningPlugins(SchemaExtensionPlugin, EntityPlugin);
+}
 
-      _Service: {
-        sdl(schema) {
-          return printFederatedSchema(schema);
-        },
-      },
-
-      _Entity: {
-        __resolveType(value) {
-          // This uses the same resolution as the Node interface, which can be found in graphile-build's NodePlugin
-          if (value === $$isQuery) {
-            if (!Query) Query = getTypeByName(inflection.builtin("Query"));
-            return Query;
-          } else if (value[$$nodeType]) {
-            return getNullableType(value[$$nodeType]);
-          }
-        },
-      },
-
-      _Any: new GraphQLScalarType({
-        name: "_Any",
-        serialize(value: any) {
-          return value;
-        },
-      }),
-    },
+/**
+ * This plugin adds the federation-specific schema parts for resolving entities by nodeId.
+ */
+const FederationSchemaNodeIdPlugin = makeFederationSchemaPlugin(build => {
+  const { resolveNode, nodeIdFieldName } = build;
+  return (data, { representations }, context, resolveInfo) => {
+    const {
+      graphile: { fieldContext },
+    } = resolveInfo;
+    return representations.map((representation: any) => {
+      if (!representation || typeof representation !== "object") {
+        throw new Error("Invalid representation");
+      }
+      const { __typename, [nodeIdFieldName]: nodeId } = representation;
+      if (!__typename || typeof nodeId !== "string") {
+        throw new Error("Failed to interpret representation");
+      }
+      return resolveNode(
+        nodeId,
+        build,
+        fieldContext,
+        data,
+        context,
+        resolveInfo
+      );
+    });
   };
 });
 
 /*
  * This plugin adds the `@key(fields: "nodeId")` directive to the types that
- * implement the Node interface, and adds these types to the _Entity union
- * defined above.
+ * implement the Node interface and marks them to be added to the _Entity union.
  */
-const AddKeyPlugin: Plugin = builder => {
-  builder.hook("build", build => {
-    build.federationEntityTypes = [];
-    return build;
-  });
-
+const AddKeyNodeIdPlugin: Plugin = builder => {
   // Find out what types implement the Node interface
   builder.hook("GraphQLObjectType:interfaces", (interfaces, build, context) => {
     const { getTypeByName, inflection, nodeIdFieldName } = build;
@@ -164,9 +215,6 @@ const AddKeyPlugin: Plugin = builder => {
     if (isRootQuery || !NodeInterface || !interfaces.includes(NodeInterface)) {
       return interfaces;
     }
-
-    // Add this to the list of types to be in the _Entity union
-    build.federationEntityTypes.push(Self);
 
     /*
      * We're going to add the `@key(fields: "nodeId")` directive to this type.
@@ -187,23 +235,9 @@ const AddKeyPlugin: Plugin = builder => {
     // We're not changing the interfaces, so return them unmodified.
     return interfaces;
   });
-
-  // Add our collected types to the _Entity union
-  builder.hook("GraphQLUnionType:types", (types, build, context) => {
-    const { Self } = context;
-    // If it's not the _Entity union, don't change it.
-    if (Self.name !== "_Entity") {
-      return types;
-    }
-    const { federationEntityTypes } = build;
-
-    // Add our types to the entity types
-    return [...types, ...federationEntityTypes];
-  });
 };
 
-// Our federation implementation combines these two plugins:
 export default makePluginByCombiningPlugins(
-  SchemaExtensionPlugin,
-  AddKeyPlugin
+  FederationSchemaNodeIdPlugin,
+  AddKeyNodeIdPlugin
 );


### PR DESCRIPTION
## Description

This allows a user to create a version of the plugin that resolves entities according to how they'd like.  This should allow users to write a version of the plugin that uses primary keys as fields for the `@key` directive without running into the concerns mentioned in https://github.com/graphile/federation/issues/1#issuecomment-507070965.  The existing version of the plugin, using `nodeId`, is created this way and exported as the default.  It's not too friendly or intuitive, so, if this is an acceptable direction, I would appreciate input on how to make it more usable.

<!-- If this PR adds a feature, what does it add and what was the motivation for it? -->
<!-- If this PR fixes an issue, what is the issue? -->
<!-- Please link to the relevant GitHub issues/Discord discussion/etc as appropriate -->

## Performance impact

I have not noticed any performance impact.  After schema construction, it shouldn't be any slower than it was before.
<!-- Detail any impact on performance of this PR, or put 'unknown' if not known -->

## Security impact

I am not aware of any risks added, though the new way of handling the `@key` directive may run into something I have not seen.
<!-- Detail any impact on security of this PR, or put 'unknown' if not known -->

## Checklist

<!-- If this PR is work in progress, please open it as a "Draft PR". -->
<!-- To tick a checkbox, change it from `[ ]` to `[x]` -->

- [ ] My code matches the project's code style and `yarn lint:fix` passes.
- [ ] I've added tests for the new feature, and `yarn test` passes.
- [ ] I have detailed the new feature in the relevant documentation.
- [ ] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [ ] If this is a breaking change I've explained why.

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
