### PR TITLE
fix: remove legacy features preventing federating 2 PostGraphiles

### DIFF
--- a/__tests__/__snapshots__/integration.test.ts.snap
+++ b/__tests__/__snapshots__/integration.test.ts.snap
@@ -58,23 +58,6 @@ interface Node {
 }
 
 type Query {
-  """
-  Exposes the root query type nested one level down. This is helpful for Relay 1
-  which can only query top level fields if they are in a particular form.
-  """
-  query: Query!
-
-  """
-  The root query type must be a \`Node\` to work well with Relay 1 mutations. This just resolves to \`query\`.
-  """
-  nodeId: ID!
-
-  """Fetches an object given its globally unique \`ID\`."""
-  node(
-    """The globally unique \`ID\`."""
-    nodeId: ID!
-  ): Node
-
   """Reads a set of \`Email\`."""
   allEmailsList(
     """Only read the first \`n\` values of the set."""

--- a/__tests__/__snapshots__/schema.test.ts.snap
+++ b/__tests__/__snapshots__/schema.test.ts.snap
@@ -59,23 +59,6 @@ interface Node {
 
 \\"\\"\\"The root query type which gives access points into the data universe.\\"\\"\\"
 type Query {
-  \\"\\"\\"
-  Exposes the root query type nested one level down. This is helpful for Relay 1
-  which can only query top level fields if they are in a particular form.
-  \\"\\"\\"
-  query: Query!
-
-  \\"\\"\\"
-  The root query type must be a \`Node\` to work well with Relay 1 mutations. This just resolves to \`query\`.
-  \\"\\"\\"
-  nodeId: ID!
-
-  \\"\\"\\"Fetches an object given its globally unique \`ID\`.\\"\\"\\"
-  node(
-    \\"\\"\\"The globally unique \`ID\`.\\"\\"\\"
-    nodeId: ID!
-  ): Node
-
   \\"\\"\\"Reads a set of \`Email\`.\\"\\"\\"
   allEmailsList(
     \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
@@ -255,24 +238,7 @@ directive @provides(fields: _FieldSet!) on FIELD_DEFINITION
 directive @key(fields: _FieldSet!) on OBJECT | INTERFACE
 
 """The root query type which gives access points into the data universe."""
-type Query implements Node {
-  """
-  Exposes the root query type nested one level down. This is helpful for Relay 1
-  which can only query top level fields if they are in a particular form.
-  """
-  query: Query!
-
-  """
-  The root query type must be a \`Node\` to work well with Relay 1 mutations. This just resolves to \`query\`.
-  """
-  nodeId: ID!
-
-  """Fetches an object given its globally unique \`ID\`."""
-  node(
-    """The globally unique \`ID\`."""
-    nodeId: ID!
-  ): Node
-
+type Query {
   """Reads a set of \`Email\`."""
   allEmailsList(
     """Only read the first \`n\` values of the set."""
@@ -360,14 +326,6 @@ type Query implements Node {
   _service: _Service! @deprecated(reason: "Only Apollo Federation should use this")
 }
 
-"""An object with a globally unique \`ID\`."""
-interface Node {
-  """
-  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  """
-  nodeId: ID!
-}
-
 type Email implements Node {
   """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
@@ -392,6 +350,14 @@ type Email implements Node {
     """
     condition: UsersEmailCondition
   ): [UsersEmail!]!
+}
+
+"""An object with a globally unique \`ID\`."""
+interface Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
 }
 
 type UsersEmail implements Node {

--- a/src/index.ts
+++ b/src/index.ts
@@ -205,10 +205,10 @@ const AddKeyPlugin: Plugin = builder => {
 /*
  * This plugin remove query/node/nodeId fields and Node interface from Query type to
  * fix `GraphQLSchemaValidationError: There can be only one type named "query/node/nodeId"` error.
- * This helps Apollo Gateway to consume two or more PostgraphQL services.
+ * This helps Apollo Gateway to consume two or more PostGraphile services.
  */
 
-const ApolloGatewayPlugin: Plugin = builder => {
+const RemoveQueryLegacyFeaturesPlugin: Plugin = builder => {
   builder.hook('GraphQLObjectType:fields', (fields, _, context) => {
     const {
       scope: { isRootQuery },
@@ -229,6 +229,7 @@ const ApolloGatewayPlugin: Plugin = builder => {
     if (!context.scope.isRootQuery) {
       return interfaces;
     }
+    // Delete all interfaces (i.e. the Node interface) from Query.
     return [];
   });
 };
@@ -237,5 +238,5 @@ const ApolloGatewayPlugin: Plugin = builder => {
 export default makePluginByCombiningPlugins(
   SchemaExtensionPlugin,
   AddKeyPlugin,
-  ApolloGatewayPlugin,
+  RemoveQueryLegacyFeaturesPlugin,
 );

--- a/src/index.ts
+++ b/src/index.ts
@@ -202,8 +202,40 @@ const AddKeyPlugin: Plugin = builder => {
   });
 };
 
-// Our federation implementation combines these two plugins:
+/*
+ * This plugin remove query/node/nodeId fields and Node interface from Query type to
+ * fix `GraphQLSchemaValidationError: There can be only one type named "query/node/nodeId"` error.
+ * This helps Apollo Gateway to consume two or more PostgraphQL services.
+ */
+
+const ApolloGatewayPlugin: Plugin = builder => {
+  builder.hook('GraphQLObjectType:fields', (fields, _, context) => {
+    const {
+      scope: { isRootQuery },
+    } = context;
+
+    // Deleting the query, node, nodeId fields from the Query type that are used by
+    // the old relay specification which are not needed for modern GraphQL clients
+    if (isRootQuery) {
+      delete fields.query;
+      delete fields.node;
+      delete fields.nodeId;
+    }
+
+    return fields;
+  });
+
+  builder.hook('GraphQLObjectType:interfaces', (interfaces, _, context) => {
+    if (!context.scope.isRootQuery) {
+      return interfaces;
+    }
+    return [];
+  });
+};
+
+// Our federation implementation combines these plugins:
 export default makePluginByCombiningPlugins(
   SchemaExtensionPlugin,
-  AddKeyPlugin
+  AddKeyPlugin,
+  ApolloGatewayPlugin,
 );


### PR DESCRIPTION
~~## Description~~

~~This plugin suffixes the `Node` interface with `nodeIdFieldName` and deletes `query/node` fields from the root `Query` type in order to fix `GraphQLSchemaValidationError: There can be only one type named "Nodequery/node"` error. This helps Apollo Gateway to consume two or more PostgraphQL services.~~

~~Only requirement for this to work is to set a unique `nodeIdFieldName` in the options parameter of `createPostGraphQLSchema/postgraphile` methods per PostgraphQL service.~~

~~More Info: https://github.com/graphile/postgraphile/issues/1505~~

---

_New description by Benjie_

When you attempt to federate two PostGraphile instances you get various errors; these turn out to boil down to conflicts on fields on the Query type itself. By removing legacy features from the Query type, two or more PostGraphile instances may be merged via Apollo Federation.

Legacy features removed:

- `Query.query: Query` field - a hack for Relay 1, not required for modern clients
- `Query` implementing the `Node` interface - there's no need for Query to implement Node; we did it "for completeness" but I've never seen anyone using it in a valuable way
- `Query.nodeId` field - see above - no need.
- `Query.node(id: ID!): Node` field - this is required as part of the GraphQL Global Object Identification Specification spec, however we're not implementing that spec with Apollo Federation so we should be able to drop it.

:rotating_light: THIS IS A BREAKING CHANGE :rotating_light: 